### PR TITLE
Platform-agnostic and optimized trailing whitespace in chomp.

### DIFF
--- a/bin/lit
+++ b/bin/lit
@@ -321,7 +321,9 @@ end
 
 -- The chomp function
 function chomp(str)
-    return str:gsub("\n$", "")
+    local n = #str
+    while n > 0 and str:find("^%s", n) do n = n - 1 end
+    return str:sub(1, n)
 end
 
 -- The literalize function
@@ -467,7 +469,7 @@ function get_locations(lines, source_dir)
     local in_codeblock = false   -- Whether we are parsing a codeblock or not
 
     for line_num,line in pairs(lines) do
-        line = chomp(line) -- Use chomp to remove the \n
+        line = chomp(line) -- Use chomp to remove the trailing whitespace
 
         if startswith(line, "@code_type") then
             local command = split(line, " ")

--- a/src/stringutil.lit
+++ b/src/stringutil.lit
@@ -62,11 +62,16 @@ end
 
 @s
 
-The chomp function removes trailing newlines
+The chomp function removes trailing newlines. Since lua pattern matching starts
+at the left, this implementation looks at characters one at a time from the
+right hand side of the string, until we hit a non whitespace character.  Copied
+from [lua-users](http://lua-users.org/wiki/CommonFunctions).
 
 --- The chomp function
 function chomp(str)
-    return str:gsub("\n$", "")
+    local n = #str
+    while n > 0 and str:find("^%s", n) do n = n - 1 end
+    return str:sub(1, n)
 end
 ---
 

--- a/src/weave.lit
+++ b/src/weave.lit
@@ -56,7 +56,7 @@ function get_locations(lines, source_dir)
     local in_codeblock = false   -- Whether we are parsing a codeblock or not
 
     for line_num,line in pairs(lines) do
-        line = chomp(line) -- Use chomp to remove the \n
+        line = chomp(line) -- Use chomp to remove the trailing whitespace
 
         if startswith(line, "@code_type") then
             local command = split(line, " ")


### PR DESCRIPTION
Today I noticed that Literate had an issue with a .lit file from a Windows machine with carriage returns [\r\n].

This pull request changes the chomp function to be platform agnostic and more whitespace agnostic in general.  It also potentially optimizes the function for long lines as lua pattern matches from the front.  Taken from [lua-users](http://lua-users.org/wiki/CommonFunctions)

