### PR TITLE
Added a very basic code block modifier implementation.

### DIFF
--- a/dsrc/main.lit
+++ b/dsrc/main.lit
@@ -56,17 +56,17 @@ string outDir = "."; // Default is current directory
 ---
 
 This program uses a number of block modifiers in order to facilitate certain functionality.
-i.e. If you don't wish a code block to be woven into the final HTML then the `no-weave` 
+i.e. If you don't wish a code block to be woven into the final HTML then the `noWeave` 
 modifier will indicate this for you.
 
 Each modifier is represented by this list of enums:
 
 --- Modifiers
 enum Modifier {
-        noWeave,
-        noTangle,
-        additive, //+=
-        coleq // :=
+    noWeave,
+    noTangle,
+    additive, //+=
+    redef // :=
 }
 ---
 

--- a/dsrc/main.lit
+++ b/dsrc/main.lit
@@ -16,6 +16,7 @@ Here is an overview:
 --- main.d
 @{Imports}
 @{Globals}
+@{Modifiers}
 
 @{getLinenums function}
 
@@ -52,6 +53,21 @@ bool weaveOnly;
 bool noOutput;
 bool noCompCmd = true;
 string outDir = "."; // Default is current directory
+---
+
+This program uses a number of block modifiers in order to facilitate certain functionality.
+i.e. If you don't wish a code block to be woven into the final HTML then the `no-weave` 
+modifier will indicate this for you.
+
+Each modifier is represented by this list of enums:
+
+--- Modifiers
+enum Modifier {
+        noWeave,
+        noTangle,
+        additive, //+=
+        coleq // :=
+}
 ---
 
 Now, to actually parse the arguments:

--- a/dsrc/parser.lit
+++ b/dsrc/parser.lit
@@ -67,7 +67,7 @@ I'll quickly list the imports here.
 import std.stdio;
 import util;
 import main;
-import std.string: split, startsWith, chomp, replace, strip;
+import std.string: split, endsWith, startsWith, chomp, replace, strip;
 import std.algorithm: canFind;
 import std.regex: matchAll, matchFirst, regex, ctRegex, splitter;
 import std.conv;
@@ -510,8 +510,8 @@ The `checkForModifiers` ugliness is due to lack of `(?|...)` and friends.
 
 First half matches for expressions *with* modifiers:
 
-    1. `(?P<namea>\S.*)` : From the first non-whitespace character ...
-    2. `[ \t]-{3}[ \t]` : Matches ` --- `
+    1. `(?P<namea>\S.*)` : Keep taking from the first non-whitespace character ...
+    2. `[ \t]-{3}[ \t]` : Until it matches ` --- `
     3. `(?P<modifiers>.+)` : Matches everything after the separator.
 
 Second half matches for no modifiers: Ether `Block name` and with a floating separator `Block Name ---`.
@@ -534,6 +534,14 @@ if (modMatch["namea"] != "") {
     curBlock.name = modMatch["namea"];
 } else if (modMatch["nameb"] != ""){
     curBlock.name = modMatch["nameb"];
+    // Check for old syntax.
+    if (curBlock.name.endsWith("+=")) {
+        curBlock.modifiers ~= Modifier.additive;
+        curBlock.name = strip(curBlock.name[0..$-2]);
+    } else if (curBlock.name.endsWith(":=")) {
+        curBlock.modifiers ~= Modifier.redef;
+        curBlock.name = strip(curBlock.name[0..$-2]);
+    }
 } else {
     error(filename, lineNum, "Something went wrong with: " ~ curBlock.name);
 }

--- a/dsrc/parser.lit
+++ b/dsrc/parser.lit
@@ -506,16 +506,40 @@ else if (matchAll(line, regex("^---.+"))) {
 @s Check for and extract modifiers.
 
 Modifier format for a code block: `--- Block Name --- noWeave +=`.
+The `checkForModifiers` ugliness is due to lack of `(?|...)` and friends.
+
+First half matches for expressions *with* modifiers:
+
+    1. `(?P<namea>\S.*)` : From the first non-whitespace character ...
+    2. `[ \t]-{3}[ \t]` : Matches ` --- `
+    3. `(?P<modifiers>.+)` : Matches everything after the separator.
+
+Second half matches for no modifiers: Ether `Block name` and with a floating separator `Block Name ---`.
+
+    4. `|(?P<nameb>\S.*?)` : Same thing as #1 but stores it in `nameb`
+    5. `[ \t]*?` : Checks for any amount of whitespace (Including none.)
+    6. `(-{1,}$` : Checks for any floating `-` and verifies that nothing else is there untill end of line.
+    7. `|$))` : Or just checks that there is nothing but the end of the line after the whitespace.
+
+Returns ether `namea` and `modifiers` or just `nameb`. 
 
 --- Parse Modifiers
-auto checkForModifiers = ctRegex!(`(.*)\s+---\s+(.*)`);
+auto checkForModifiers = ctRegex!(`(?P<namea>\S.*)[ \t]-{3}[ \t](?P<modifiers>.+)|(?P<nameb>\S.*?)[ \t]*?(-{1,}$|$)`);
 auto splitOnSpace = ctRegex!(r"(\s+)");
 auto modMatch = matchFirst(curBlock.name, checkForModifiers);
 
-if (modMatch) {
-    curBlock.name = modMatch[1]; // Name without params.
+// matchFirst returns unmatched groups as empty strings
 
-    foreach (m; splitter(modMatch[2], splitOnSpace)) {
+if (modMatch["namea"] != "") {
+    curBlock.name = modMatch["namea"];
+} else if (modMatch["nameb"] != ""){
+    curBlock.name = modMatch["nameb"];
+} else {
+    error(filename, lineNum, "Something went wrong with: " ~ curBlock.name);
+}
+
+if (modMatch["modifiers"]) {
+    foreach (m; splitter(modMatch["modifiers"], splitOnSpace)) {
         switch(m) {
             case "+=":
                 curBlock.modifiers ~= Modifier.additive;

--- a/dsrc/parser.lit
+++ b/dsrc/parser.lit
@@ -202,6 +202,7 @@ class Block {
         b.isCodeblock = isCodeblock;
         b.codeType = codeType;
         b.commentString = commentString;
+        b.modifiers = modifiers;
 
         foreach (Line l; lines) {
             b.lines ~= l.dup();
@@ -504,32 +505,35 @@ else if (matchAll(line, regex("^---.+"))) {
 
 @s Check for and extract modifiers.
 
+Modifier format for a code block: `--- Block Name --- noWeave +=`.
+
 --- Parse Modifiers
 auto checkForModifiers = ctRegex!(`(.*)\s+---\s+(.*)`);
 auto splitOnSpace = ctRegex!(r"(\s+)");
 auto modMatch = matchFirst(curBlock.name, checkForModifiers);
 
 if (modMatch) {
-        curBlock.name = modMatch[1]; // Name without params.
+    curBlock.name = modMatch[1]; // Name without params.
 
-        foreach (m; splitter(modMatch[2], splitOnSpace)) {
-                switch(m) {
-                        case "+=":
-                        curBlock.modifiers ~= Modifier.additive;
-                        break;
-                        case ":=":
-                        break;
-                        case "noWeave":
-                        curBlock.modifiers ~= Modifier.noWeave;
-                        break;
-                        case "noTangle":
-                        curBlock.modifiers ~= Modifier.noTangle;
-                        break;
-                        default:
-                        writeln("Un-implemented modifier: " ~ m);
-                        break;
-                }
+    foreach (m; splitter(modMatch[2], splitOnSpace)) {
+        switch(m) {
+            case "+=":
+                curBlock.modifiers ~= Modifier.additive;
+                break;
+            case ":=":
+                curBlock.modifiers ~= Modifier.redef;
+                break;
+            case "noWeave":
+                curBlock.modifiers ~= Modifier.noWeave;
+                break;
+            case "noTangle":
+                curBlock.modifiers ~= Modifier.noTangle;
+                break;
+            default:
+                error(filename, lineNum, "Invalid modifier: " ~ m);
+                break;
         }
+    }
 
 }
 ---

--- a/dsrc/parser.lit
+++ b/dsrc/parser.lit
@@ -66,9 +66,10 @@ I'll quickly list the imports here.
 --- Imports
 import std.stdio;
 import util;
+import main;
 import std.string: split, startsWith, chomp, replace, strip;
 import std.algorithm: canFind;
-import std.regex: matchAll, matchFirst, regex;
+import std.regex: matchAll, matchFirst, regex, ctRegex, splitter;
 import std.conv;
 import std.path: extension;
 ---
@@ -179,8 +180,11 @@ class Block {
     public string codeType;
     public string commentString;
 
+    public Modifier[] modifiers;
+
     this() {
         lines = [];
+        modifiers = [];
     }
 
     string text() {
@@ -484,6 +488,8 @@ else if (matchAll(line, regex("^---.+"))) {
     curBlock.isCodeblock = true;
     curBlock.name = strip(line[3..$]);
 
+    @{Parse Modifiers}
+
     foreach (cmd; curSection.commands) {
         if (cmd.name == "@code_type") {
             curBlock.codeType = cmd.args;
@@ -493,6 +499,38 @@ else if (matchAll(line, regex("^---.+"))) {
     }
 
     inCodeblock = true;
+}
+---
+
+@s Check for and extract modifiers.
+
+--- Parse Modifiers
+auto checkForModifiers = ctRegex!(`(.*)\s+---\s+(.*)`);
+auto splitOnSpace = ctRegex!(r"(\s+)");
+auto modMatch = matchFirst(curBlock.name, checkForModifiers);
+
+if (modMatch) {
+        curBlock.name = modMatch[1]; // Name without params.
+
+        foreach (m; splitter(modMatch[2], splitOnSpace)) {
+                switch(m) {
+                        case "+=":
+                        curBlock.modifiers ~= Modifier.additive;
+                        break;
+                        case ":=":
+                        break;
+                        case "noWeave":
+                        curBlock.modifiers ~= Modifier.noWeave;
+                        break;
+                        case "noTangle":
+                        curBlock.modifiers ~= Modifier.noTangle;
+                        break;
+                        default:
+                        writeln("Un-implemented modifier: " ~ m);
+                        break;
+                }
+        }
+
 }
 ---
 

--- a/dsrc/util.lit
+++ b/dsrc/util.lit
@@ -13,6 +13,7 @@ It has functions for reading the entire source of a file, and functions
 for reporting errors and warnings.
 
 --- util.d
+import main;
 import std.stdio;
 import std.conv;
 import parser;
@@ -22,7 +23,6 @@ import std.path;
 @{readall function}
 @{error function}
 @{warning function}
-@{realname function}
 @{leadingWS function}
 @{getCodeblocks function}
 @{getChapterHtmlFile function}
@@ -71,23 +71,6 @@ void warn(string file, int line, string message) {
 }
 ---
 
-@s Realname function
-
-Sometimes a block name will be `name +=` and here it is useful to strip
-off the end `+=` because that is not really part of the block name. This
-function does that.
-
---- realname function
-string realname(string name) {
-    name = strip(name);
-    if (name.endsWith("+=") || name.endsWith(":=")) {
-        return strip(name[0..$ - 2]);
-    } else {
-        return name;
-    }
-}
----
-
 @s Leading Whitespace function
 
 This function returns the leading whitespace of the input string.
@@ -129,7 +112,7 @@ void getCodeblocks(Program p,
                             copy.name = copy.name[1..$-1];
                         }
                     }
-                    if ((!copy.name.endsWith("+=")) && (!copy.name.endsWith(":="))) {
+                    if ((!copy.modifiers.canFind(Modifier.additive)) && (!copy.modifiers.canFind(Modifier.redef))) {
                         codeblocks[copy.name] = copy;
                         if (copy.isRootBlock) {
                             rootCodeblocks[copy.name] = copy;
@@ -144,16 +127,16 @@ void getCodeblocks(Program p,
 
     // Now we go through every codeblock in tempCodeblocks and apply the += and :=
     foreach (b; tempCodeblocks) {
-        if (b.name.endsWith("+=")) {
-            auto index = b.name.length - 2;
+        if (b.modifiers.canFind(Modifier.additive)) {
+            auto index = b.name.length;
             string name = strip(b.name[0..index]);
             if ((name in codeblocks) is null) {
                 error(p.file, b.startLine, "Trying to add to {" ~ name ~ "} which does not exist");
             } else {
                 codeblocks[name].lines ~= b.lines;
             }
-        } else if (b.name.endsWith(":=")) {
-            auto index = b.name.length - 2;
+        } else if (b.modifiers.canFind(Modifier.redef)) {
+            auto index = b.name.length;
             string name = strip(b.name[0..index]);
             if ((name in codeblocks) is null) {
                 error(p.file, b.startLine, "Trying to redefine {" ~ name ~ "} which does not exist");

--- a/dsrc/weaver.lit
+++ b/dsrc/weaver.lit
@@ -41,22 +41,21 @@ foreach (chapter; p.chapters) {
     foreach (s; chapter.sections) {
         foreach (block; s.blocks) {
             if (block.isCodeblock) {
-                
+
                 if (block.modifiers.canFind(Modifier.noWeave)) {
-                        writeln("This block is removed");
-                        block.isCodeblock = false;
-                        block.lines = [];
-                        continue;
+                    block.isCodeblock = false; // Prevents it from passing further checks. Hacky?
+                    block.lines = []; // Is this the best way to prevent it from printing anything down the line? 
+                    continue;
                 }
 
                 if (block.modifiers.canFind(Modifier.additive)) {
-                    if (realname(block.name) !in addLocations || !addLocations[realname(block.name)].canFind(to!string(s.num)))
-                        addLocations[realname(block.name)] ~= chapter.num() ~ ":" ~ to!string(s.num);
-                } else if (block.modifiers.canFind(Modifier.coleq)) {
-                    if (realname(block.name) !in redefLocations || !redefLocations[realname(block.name)].canFind(to!string(s.num)))
-                        redefLocations[realname(block.name)] ~= chapter.num() ~ ":" ~ to!string(s.num);
+                    if (block.name !in addLocations || !addLocations[block.name].canFind(to!string(s.num)))
+                        addLocations[block.name] ~= chapter.num() ~ ":" ~ to!string(s.num);
+                } else if (block.modifiers.canFind(Modifier.redef)) {
+                    if (block.name !in redefLocations || !redefLocations[block.name].canFind(to!string(s.num)))
+                        redefLocations[block.name] ~= chapter.num() ~ ":" ~ to!string(s.num);
                 } else {
-                    defLocations[realname(block.name)] = chapter.num() ~ ":" ~ to!string(s.num);
+                    defLocations[block.name] = chapter.num() ~ ":" ~ to!string(s.num);
                 }
 
                 foreach (lineObj; block.lines) {
@@ -303,10 +302,10 @@ string chapterNum;
 string def;
 string defLocation;
 string htmlFile = "";
-if (realname(block.name) !in defLocations) {
-    error(c.file, block.startLine, "{" ~ realname(block.name) ~ "} is never defined");
+if (block.name !in defLocations) {
+    error(c.file, block.startLine, "{" ~ block.name ~ "} is never defined");
 } else {
-    def = defLocations[realname(block.name)];
+    def = defLocations[block.name];
     defLocation = def;
     auto index = def.indexOf(":");
     string chapter = def[0..index];
@@ -332,9 +331,9 @@ We simple put the title in in a strong tag if it is a root codeblock to make it 
 --- Make the title bold if necessary
 string name;
 if (block.isRootBlock) {
-    name = "<strong>" ~ realname(block.name) ~ "</strong>";
+    name = "<strong>" ~ block.name ~ "</strong>";
 } else {
-    name = realname(block.name);
+    name = block.name;
 }
 ---
 
@@ -404,8 +403,8 @@ have a few if statements to figure out the grammar -- where to put the `and`
 and whether to have plurals and whatnot.
 
 --- Write the 'see also' links
-if (realname(block.name) in addLocations) {
-    string[] locations = dup(addLocations[realname(block.name)]);
+if (block.name in addLocations) {
+    string[] locations = dup(addLocations[block.name]);
 
     if (locations.canFind(c.num() ~ ":" ~ to!string(s.num))) {
         locations = remove(locations, locations.countUntil(c.num() ~ ":" ~ to!string(s.num)));
@@ -450,8 +449,8 @@ This is pretty much the same as the 'see also' links except we use the
 `useLocations` array.
 
 --- Write the 'also used in' links
-if (realname(block.name) in useLocations) {
-    string[] locations = dup(useLocations[realname(block.name)]);
+if (block.name in useLocations) {
+    string[] locations = dup(useLocations[block.name]);
 
     if (locations.canFind(c.num() ~ ":" ~ to!string(s.num))) {
         locations.remove(locations.countUntil(c.num() ~ ":" ~ to!string(s.num)));

--- a/dsrc/weaver.lit
+++ b/dsrc/weaver.lit
@@ -41,10 +41,18 @@ foreach (chapter; p.chapters) {
     foreach (s; chapter.sections) {
         foreach (block; s.blocks) {
             if (block.isCodeblock) {
-                if (block.name.indexOf("+=") != -1) {
+                
+                if (block.modifiers.canFind(Modifier.noWeave)) {
+                        writeln("This block is removed");
+                        block.isCodeblock = false;
+                        block.lines = [];
+                        continue;
+                }
+
+                if (block.modifiers.canFind(Modifier.additive)) {
                     if (realname(block.name) !in addLocations || !addLocations[realname(block.name)].canFind(to!string(s.num)))
                         addLocations[realname(block.name)] ~= chapter.num() ~ ":" ~ to!string(s.num);
-                } else if (block.name.indexOf(":=") != -1) {
+                } else if (block.modifiers.canFind(Modifier.coleq)) {
                     if (realname(block.name) !in redefLocations || !redefLocations[realname(block.name)].canFind(to!string(s.num)))
                         redefLocations[realname(block.name)] ~= chapter.num() ~ ":" ~ to!string(s.num);
                 } else {

--- a/dsrc/weaver.lit
+++ b/dsrc/weaver.lit
@@ -43,8 +43,7 @@ foreach (chapter; p.chapters) {
             if (block.isCodeblock) {
 
                 if (block.modifiers.canFind(Modifier.noWeave)) {
-                    block.isCodeblock = false; // Prevents it from passing further checks. Hacky?
-                    block.lines = []; // Is this the best way to prevent it from printing anything down the line? 
+                    defLocations[block.name] = "noWeave";
                     continue;
                 }
 
@@ -200,10 +199,12 @@ foreach (s; c.sections) {
               noheading ~ ">" ~ to!string(s.num) ~ ". " ~ s.title ~ "</h4></a>\n";
 
     foreach (block; s.blocks) {
-        if (!block.isCodeblock) {
-            @{Weave a prose block}
-        } else {
-            @{Weave a code block}
+        if (!block.modifiers.canFind(Modifier.noWeave)) {
+            if (!block.isCodeblock) {
+                @{Weave a prose block}
+            } else {
+                @{Weave a code block}
+            }
         }
     }
     output ~= "</div>\n";
@@ -366,7 +367,7 @@ string line = lineObj.text;
 string strippedLine = strip(line);
 if (strippedLine.startsWith("@{") && strippedLine.endsWith("}")) {
     @{Link a used codeblock}
-} else {
+} else { 
     output ~= line.replace("&", "&amp;").replace(">", "&gt;").replace("<", "&lt;") ~ "\n";
 }
 ---
@@ -381,7 +382,7 @@ def = "";
 defLocation = "";
 if (strip(strippedLine[2..$ - 1]) !in defLocations) {
     error(c.file, lineObj.lineNum, "{" ~ strip(strippedLine[2..$ - 1]) ~ "} is never defined");
-} else {
+} else if (defLocations[strip(strippedLine[2..$ - 1])] != "noWeave") {
     def = defLocations[strippedLine[2..$ - 1]];
     defLocation = def;
     auto index = def.indexOf(":");


### PR DESCRIPTION
I don't think this is up to par at all yet. But could you look it over and see if I am going in the right direction?

I used the following for testing while editing: https://gist.github.com/BorisKourt/ea0090f2b6d38d9c726a

#### What I am trying:

Add an `enum` array `Modifiers` that can be grown if necessary. (It is in `main.lit`)

Rather than adding a bunch of separate fields to the code block class I added an empty array for storing these Modifiers. 

When the first line of the code block is parsed, I check if there is a modifier indicator `---` and then grab anything after it. Check if these are known items, and then add anything that matches to the `modifiers` array in the code block. 

So the syntax looks like: 

```lit
--- inTangle.d --- noWeave +=
// Code!
---
```

(The inspiration for `---` is from the way `--` is used in certain command line programs for separating settings from arguments.)

From then on just do checks against those modifiers rather than the strings `"+="` or `"noWeave"` in the block title. (You can see the changes for that in weave.lit)

#### Problems:

I don't think `noTangle` is necessary as it already wont tangle if you didn't reference a block in another block? 

This will break the current way `+=` and `:=` is implemented (they would require the `--- Block Name --- := ...` syntax)

Referencing (`@{code block name}`) in a `noWeave` modified code block is currently not done. 

And probably many others :(  

***
How would you like me to adjust this? 
