### PR TITLE
Support for hierarchically organized sections

### DIFF
--- a/lit/parser.lit
+++ b/lit/parser.lit
@@ -144,21 +144,53 @@ class Chapter {
 }
 ---
 
-@s The Sections class
+@s The Section class
 
 A section has a title, commands, a number, and a series of blocks, which can either be
-blocks of code, or blocks of prose.
+blocks of code, or blocks of prose. 
+
+We also attribute a level to sections which allows us to appear our 
+sections be organized hierarchically. Six levels are supported at the 
+moment; in the final document these are translated to HTML tags `<h1>` 
+to `<h6>`. 
+
+Accordingly, the section number is an array of six numbers in fact. Two 
+support functions are needed to handle the number array seamlessly: 
+
+* First we need a function to convert this array to a string - the `numToString`
+  class method does this for us. The only trick we need to consider here is not 
+  to include trailing zeros to our result string.
+  
+* Second, we need a function to increase the numbering according to the section's
+  level. The `increaseSectionNum` function called during chapter parsing (i.e. 
+  in the `parseChapter` call) is responsible for this (for more details see the
+  description of `parseChapter`).
 
 --- Section class
 class Section {
     public string title;
     public Command[] commands;
     public Block[] blocks;
-    public int num;
+    public int[6] num;
+    public int level;
 
     this() {
         commands = [];
         blocks = [];
+    }
+    
+    string numToString()
+    {
+        string numString;
+        for(int i = 5; i >= 0; i--)
+        {
+            if (numString == "" && num[i] == 0)
+            {
+                continue;
+            }
+            numString = to!string(num[i]) ~ (numString == "" ? "" : ".") ~ numString;
+        }
+        return numString;
     }
 }
 ---
@@ -351,9 +383,12 @@ Before doing any parsing, we resolve the `@include` statements by replacing them
 the contents of the file that was included. Then we loop through each line in the source
 and parse it, provided that it is not a comment (starting with `//`);
 
+
+
 --- parseChapter function
 Chapter parseChapter(Chapter chapter, string src) {
     @{Initialize some variables}
+    @{Increase section number}
 
     string[] blocks = [];
 
@@ -413,7 +448,7 @@ the current change being parsed.
 
 --- Initialize some variables +=
 Section curSection;
-int sectionNum = 0;
+int[6] sectionNum = [0, 0, 0, 0, 0, 0];
 Block curBlock;
 Change curChange;
 ---
@@ -510,7 +545,7 @@ if (startsWith(line, "@title")) {
 
 @s Parsing a Section Definition
 
-When a new section is created (using `@s`), we should add the current section to the list
+When a new section is created (using `@s1` .. `@s6`), we should add the current section to the list
 of sections for the chapter, and then we should create a new section, which becomes the
 current section.
 
@@ -527,13 +562,39 @@ else if (startsWith(line, "@s")) {
     if (curSection !is null) {
         chapter.sections ~= curSection;
     }
+    if (!"123456".canFind(to!string(line[2])))
+    {
+        error(filename, lineNum, "Illegal section start command");
+    }
     curSection = new Section();
-    curSection.title = strip(line[2..$]);
+    curSection.title = strip(line[3..$]);
+    curSection.level = line[2].to!string.to!int - 1;
     curSection.commands = chapter.commands ~ curSection.commands;
-    curSection.num = ++sectionNum;
+    increaseSectionNum(curSection.level);
+    curSection.num = sectionNum;
 
     curBlock = new Block();
     curBlock.isCodeblock = false;
+}
+---
+
+Section number increase - since we support six levels of sections to have a 
+hierarchical structure even inside a chapter - depends on the section's level.
+When we increase the number of a certain level, all lower levels need to be 
+zeroed out. The `increaseSectionNum` function does this job for us.
+
+--- Increase section number
+void increaseSectionNum(int level)
+{
+    if (level > 5)
+    {
+        throw new Exception("Levels higher than 5 are not supported in 'increaseSectionNum'");
+    }
+    for (int i = 5; i > level; i--)
+    {
+        sectionNum[i] = 0;
+    }
+    sectionNum[level]++;
 }
 ---
 

--- a/lit/weaver.lit
+++ b/lit/weaver.lit
@@ -53,19 +53,19 @@ foreach (chapter; p.chapters) {
                 @{Check if it's a root block}
 
                 if (block.modifiers.canFind(Modifier.additive)) {
-                    if (block.name !in addLocations || !addLocations[block.name].canFind(to!string(s.num)))
-                        addLocations[block.name] ~= chapter.num() ~ ":" ~ to!string(s.num);
+                    if (block.name !in addLocations || !addLocations[block.name].canFind(s.numToString()))
+                        addLocations[block.name] ~= chapter.num() ~ ":" ~ s.numToString();
                 } else if (block.modifiers.canFind(Modifier.redef)) {
-                    if (block.name !in redefLocations || !redefLocations[block.name].canFind(to!string(s.num)))
-                        redefLocations[block.name] ~= chapter.num() ~ ":" ~ to!string(s.num);
+                    if (block.name !in redefLocations || !redefLocations[block.name].canFind(s.numToString()))
+                        redefLocations[block.name] ~= chapter.num() ~ ":" ~ s.numToString();
                 } else {
-                    defLocations[block.name] = chapter.num() ~ ":" ~ to!string(s.num);
+                    defLocations[block.name] = chapter.num() ~ ":" ~ s.numToString();
                 }
 
                 foreach (lineObj; block.lines) {
                     string line = strip(lineObj.text);
                     if (line.startsWith("@{") && line.endsWith("}")) {
-                        useLocations[line[2..$ - 1]] ~= chapter.num() ~ ":" ~ to!string(s.num);
+                        useLocations[line[2..$ - 1]] ~= chapter.num() ~ ":" ~ s.numToString();
                     }
                 }
             }
@@ -294,12 +294,12 @@ between the title and the prose.
 --- Write the body
 output ~= "<body onload=\"prettyPrint()\">\n"
           "<section>\n"
-          "<h1>" ~ c.title ~ "</h1>\n";
+          "<p class=\"title\">" ~ c.title ~ "</p>\n";
 
 foreach (s; c.sections) {
     string noheading = s.title == "" ? " class=\"noheading\"" : "";
-    output ~= "<a name=\"" ~ c.num() ~ ":" ~ to!string(s.num) ~ "\"><div class=\"section\"><h4" ~
-              noheading ~ ">" ~ to!string(s.num) ~ ". " ~ s.title ~ "</h4></a>\n";
+    output ~= "<a name=\"" ~ c.num() ~ ":" ~ s.numToString() ~ "\"><div class=\"section\"><h" ~ to!string(s.level + 1) ~
+              noheading ~ ">" ~ s.numToString() ~ ". " ~ s.title ~ "</h" ~ to!string(s.level + 1) ~ "></a>\n";
 
     foreach (block; s.blocks) {
         if (!block.modifiers.canFind(Modifier.noWeave)) {
@@ -558,8 +558,8 @@ string linkLocations(string text, string[][string] sectionLocations, Program p, 
     if (block.name in sectionLocations) {
         string[] locations = dup(sectionLocations[block.name]).noDupes;
 
-        if (locations.canFind(c.num() ~ ":" ~ to!string(s.num))) {
-            locations = remove(locations, locations.countUntil(c.num() ~ ":" ~ to!string(s.num)));
+        if (locations.canFind(c.num() ~ ":" ~ s.numToString())) {
+            locations = remove(locations, locations.countUntil(c.num() ~ ":" ~ s.numToString()));
         }
 
         if (locations.length > 0) {
@@ -912,7 +912,7 @@ string colorschemeCSS = q"DELIMITER
 DELIMITER";
 
 string defaultCSS = q"DELIMITER
-body{min-width:200px;max-width:850px;margin:0 auto;padding:30px;}.chapter-nav{font-size: 10pt;}a:link,a:visited{color:#00f}.codeblock_name,code,pre.prettyprint{font-family:Monaco,"Lucida Console",monospace}body{font-size:14pt}.codeblock_name,.math,.seealso,code{font-size:10pt}.codeblock{page-break-inside:avoid;padding-bottom:15px}.math{text-indent:0}pre.prettyprint{font-size:10pt;padding:10px;border-radius:10px;border:none;white-space:pre-wrap}.codeblock_name{margin-top:1.25em;display:block}a:link{text-decoration:none}a:link:not(.lit):hover{color:#00f;text-decoration:underline}a:link:active{color:red}h4{padding-right:1.25em}h4.noheading{margin-bottom:0}h1{text-align:center}code{padding:2px}pre{-moz-tab-size:4;-o-tab-size:4;tab-size:4}p:not(.notp){margin:0;text-indent:2em}.two-col{list-style-type:none}.two-col li:before{content:'-';padding:5px;margin-right:5px;color:orange;background-color:#fff;display:inline-block}@media print{body{font-size:10pt}pre.prettyprint{font-size:8pt}.seealso{font-size:9pt}.codeblock_name,.math,code{font-size:8pt}.math{text-indent:0}}
+body{min-width:200px;max-width:850px;margin:0 auto;padding:30px;}.chapter-nav{font-size: 10pt;}a:link,a:visited{color:#00f}.codeblock_name,code,pre.prettyprint{font-family:Monaco,"Lucida Console",monospace}body{font-size:14pt}.codeblock_name,.math,.seealso,code{font-size:10pt}.codeblock{page-break-inside:avoid;padding-bottom:15px}.math{text-indent:0}pre.prettyprint{font-size:10pt;padding:10px;border-radius:10px;border:none;white-space:pre-wrap}.codeblock_name{margin-top:1.25em;display:block}a:link{text-decoration:none}a:link:not(.lit):hover{color:#00f;text-decoration:underline}a:link:active{color:red}h4{padding-right:1.25em}h4.noheading{margin-bottom:0}h1{text-align:left}.title{text-align:center;font-size:20pt}code{padding:2px}pre{-moz-tab-size:4;-o-tab-size:4;tab-size:4}p:not(.notp){margin:0;text-indent:2em}.two-col{list-style-type:none}.two-col li:before{content:'-';padding:5px;margin-right:5px;color:orange;background-color:#fff;display:inline-block}@media print{body{font-size:10pt}pre.prettyprint{font-size:8pt}.seealso{font-size:9pt}.codeblock_name,.math,code{font-size:8pt}.math{text-indent:0}}
 DELIMITER";
 ---
 


### PR DESCRIPTION
The idea is to support section titles like '1.1.2. Some subsection title'. I usually find this hierarchical numbering easier to follow, especially in longer documents.

The suggested modifications drop support for the '@s' command and introduce new '@s1' .. '@s6' commands where the user can determine the respective section's level. In the final HTML document these get translated to '<h1>' .. '<h6>'.

As these modifications reserve '<h1>' to '<h6>' for sections, the document's title (or chapter's title, using Literate's terminology) in the HTML was changed from '<h1>' to '<p class="title">'.