### PR TITLE
Add the noHeader block directive

### DIFF
--- a/lit/main.lit
+++ b/lit/main.lit
@@ -88,8 +88,9 @@ Each modifier is represented by this list of enums:
 enum Modifier {
     noWeave,
     noTangle, // Not yet implemented
+    noHeader, // Don't print the block header
     additive, // +=
-    redef // :=
+    redef, // :=
 }
 ---
 

--- a/lit/parser.lit
+++ b/lit/parser.lit
@@ -638,6 +638,9 @@ if (modMatch["modifiers"]) {
             case "noTangle":
                 curBlock.modifiers ~= Modifier.noTangle;
                 break;
+            case "noHeader":
+                curBlock.modifiers ~= Modifier.noHeader;
+                break;
             default:
                 error(filename, lineNum, "Invalid modifier: " ~ m);
                 break;

--- a/lit/tangler.lit
+++ b/lit/tangler.lit
@@ -20,6 +20,7 @@ Here is an overview of the file:
 import globals;
 import std.string;
 import std.stdio;
+import std.algorithm: canFind;
 import parser;
 import util;
 import std.conv: to;
@@ -90,7 +91,7 @@ void writeCode(Block[string] codeblocks, string blockName, File file, string fil
     Block block = codeblocks[blockName];
 
     if (block.commentString != "") {
-        if (!noOutput)
+        if (!noOutput && !block.modifiers.canFind(Modifier.noHeader))
             file.writeln(whitespace ~ block.commentString.replace("%s", blockName));
     }
 


### PR DESCRIPTION
`noHeader` prevents the block header from appearing in the tangle output when set, allowing for code blocks where a comment might otherwise be sensitive text.

### Motivation

I'm writing a literate Haskell module which uses a code block for the GHC language pragma, but having a comment in the contents of the pragma breaks the functionality. I needed to be able to mark the block so it doesn't generate the header comment.