### PR TITLE
Warn when book chapters set their own title after it's in the ToC

### DIFF
--- a/lit/parser.lit
+++ b/lit/parser.lit
@@ -500,10 +500,17 @@ if (line.split().length > 1) {
 }
 ---
 
-Parsing an `@title` command is even simpler.
+Parsing an `@title` command is even simpler - with one caveat: in books, titles can be set in the table of contents, and then reset in the chapter file. To avoid any confusion, we warn where we can detect that the title has already been set, and add a hint if we're currently in a book.
 
 --- Parse a title command
 if (startsWith(line, "@title")) {
+    if (chapter.title != "") {
+        auto warning = ["found a @title command when the title has already been set"];
+        if (isBook) {
+            warning ~= ["perhaps the title is set in the table of contents?"];
+        }
+        warn(filename, lineNum, warning);   
+    }
     chapter.title = strip(line[6..$]);
 }
 ---

--- a/lit/util.lit
+++ b/lit/util.lit
@@ -19,10 +19,12 @@ import std.conv;
 import parser;
 import std.string;
 import std.algorithm: canFind;
+import std.array: replicate;
 import std.regex: matchAll, regex;
 import std.path;
 
 @{readall function}
+@{message function}
 @{error function}
 @{warning function}
 @{leadingWS function}
@@ -61,15 +63,35 @@ string readall() {
 
 These functions simply write errors or warnings to stdout.
 
+--- message function
+void emit_formatted_messages(string file, int line, string kind, string[] messages) {
+    auto header = "%s:%d:%s:".format(file, line, kind);
+    auto whitespace = replicate(" ", header.length);
+
+    for(int i = 0; i < messages.length; i++) {
+        auto leading = (i == 0) ? header : whitespace;
+        writeln(leading, messages[i]);
+    }
+}
+---
+
 --- error function
 void error(string file, int line, string message) {
-    writeln(file, ":", line, ":error: ", message);
+    error(file, line, [message]);
+}
+
+void error(string file, int line, string[] messages) {
+    emit_formatted_messages(file, line, "error", messages);
 }
 ---
 
 --- warning function
 void warn(string file, int line, string message) {
-    writeln(file, ":", line, ":warning: ", message);
+    warn(file, line, [message]);
+}
+
+void warn(string file, int line, string[] messages) {
+    emit_formatted_messages(file, line, "warning", messages);
 }
 ---
 


### PR DESCRIPTION
Goes some way to addressing #30 - also warns whenever a file has two `@title` commands, as a little benefit.