### PR TITLE
fix windows build error

### DIFF
--- a/lit/tangle/src/util.d
+++ b/lit/tangle/src/util.d
@@ -6,6 +6,7 @@ import parser;
 import std.string;
 import std.path;
 import std.regex;
+import std.algorithm: canFind;
 
 // readall function
 // Read from a file


### PR DESCRIPTION
we can build it on windows 10 now!

resolved those error
```
lit\tangle\src\util.d(55,41): Error: no property canFind for type main.Modifier[]
lit\tangle\src\util.d(55,89): Error: no property canFind for type main.Modifier[]
lit\tangle\src\util.d(70,24): Error: no property canFind for type main.Modifier[]
lit\tangle\src\util.d(78,31): Error: no property canFind for type main.Modifier[]
```