### PR TITLE
Create directories for output files

### DIFF
--- a/lit/tangle/src/util.d
+++ b/lit/tangle/src/util.d
@@ -1,5 +1,6 @@
 // util.d
 import main;
+import std.algorithm : canFind;
 import std.stdio;
 import std.conv;
 import parser;

--- a/lit/tangler.lit
+++ b/lit/tangler.lit
@@ -18,6 +18,9 @@ Here is an overview of the file:
 
 --- tangler.d
 import globals;
+import std.file;
+import std.path;
+import std.range;
 import std.string;
 import std.stdio;
 import std.algorithm: canFind;
@@ -71,8 +74,16 @@ the code.
 foreach (b; rootCodeblocks) {
     string filename = b.name;
     File f;
-    if (!noOutput)
-        f = File(outDir ~ "/" ~ filename, "w");
+    if (!noOutput) {
+        string fname = std.path.buildNormalizedPath(outDir, filename);
+
+        string dname = std.path.buildPath(std.range.dropBack(std.path.pathSplitter(fname), 1));
+        if (dname != "") {
+            std.file.mkdirRecurse(dname);
+        }
+
+        f = File(fname, "w");
+    }
 
     writeCode(codeblocks, b.name, f, filename, "");
     if (!noOutput)


### PR DESCRIPTION
If we name an output file `directory/filename.ext`, `lit` will now create `directory` and any of its child directories as needed.