### PR TITLE
fix compilation with dmd v2.091.1

### DIFF
--- a/lit/tangle/src/util.d
+++ b/lit/tangle/src/util.d
@@ -6,6 +6,7 @@ import parser;
 import std.string;
 import std.path;
 import std.regex;
+import std.algorithm;
 
 // readall function
 // Read from a file


### PR DESCRIPTION
Fixes a failure to build with recent DMD compilers:

```
src/util.d(55,41): Error: no property canFind for type main.Modifier[]
```

And several more instances of the same.